### PR TITLE
Call pip as module

### DIFF
--- a/bin/pyenv-migrate
+++ b/bin/pyenv-migrate
@@ -58,6 +58,7 @@ LOG_PATH="${TMP}/python-build.${SEED}.log"
 PIP_REQUIREMENTS="${TMP}/requirements.${SEED}.txt"
 
 trap migration_failed ERR
+# Run Pip via -m as a workaround to reduce breakage from https://github.com/pyenv/pyenv/issues/2417
 PYENV_VERSION="${src}" pyenv-exec python -m pip freeze >> "${PIP_REQUIREMENTS}"
 PYENV_VERSION="${dst}" pyenv-exec python -m pip install --requirement "${PIP_REQUIREMENTS}"
 pyenv-rehash

--- a/bin/pyenv-migrate
+++ b/bin/pyenv-migrate
@@ -58,8 +58,8 @@ LOG_PATH="${TMP}/python-build.${SEED}.log"
 PIP_REQUIREMENTS="${TMP}/requirements.${SEED}.txt"
 
 trap migration_failed ERR
-PYENV_VERSION="${src}" pyenv-exec pip freeze >> "${PIP_REQUIREMENTS}"
-PYENV_VERSION="${dst}" pyenv-exec pip install --requirement "${PIP_REQUIREMENTS}"
+PYENV_VERSION="${src}" pyenv-exec python -m pip freeze >> "${PIP_REQUIREMENTS}"
+PYENV_VERSION="${dst}" pyenv-exec python -m pip install --requirement "${PIP_REQUIREMENTS}"
 pyenv-rehash
 rm -f "${PIP_REQUIREMENTS}"
 trap - ERR


### PR DESCRIPTION
Call pip as python module to ensure that we call `pip freeze` and `pip install` from right python version.